### PR TITLE
Change LOG_INFO

### DIFF
--- a/src/who_logged.cpp
+++ b/src/who_logged.cpp
@@ -60,7 +60,7 @@ public:
                 break;
         }
 
-        LOG_WARN("module", "Player '{}' has logged in : Level '{}' : Class '{}' : IP '{}' : AccountID '{}'", playerName.c_str(), pLevel, pClass.c_str(), playerIP.c_str(), pAccountID);
+        LOG_INFO("module", "Player '{}' has logged in : Level '{}' : Class '{}' : IP '{}' : AccountID '{}'", playerName.c_str(), pLevel, pClass.c_str(), playerIP.c_str(), pAccountID);
     }
 };
 


### PR DESCRIPTION
Previously, I had used the LOG_INFO option, but as it didn't show the results, I changed it to LOG_WARN. But evidently I was doing something wrong, because now I changed it back to INFO and it worked.

![info](https://user-images.githubusercontent.com/2810187/170714123-b81afc9a-99de-468e-987b-71f8d5611031.png)